### PR TITLE
Add BetterReload Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Ensure the [PacketEvents](https://modrinth.com/plugin/packetevents) library is i
 - **Bypass** - The plugin allows players to bypass the checks if they have the `TotemGuard.Bypass` permission and the
   bypass setting is enabled.
 - **Bedrock Exception** - The plugin doesn't check players who are using Bedrock Edition, preventing false positives.
+- **Supports BetterReload** - This plugin integrates with the [BetterReload](https://modrinth.com/plugin/betterreload) plugin.
 
 ## Commands
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,9 @@ repositories {
     maven {
         url = uri("https://repo.codemc.io/repository/maven-releases/")
     }
+    maven {
+        url = uri("https://jitpack.io")
+    }
 }
 
 java {
@@ -28,6 +31,7 @@ dependencies {
     compileOnly(libs.configlib.yaml)
     compileOnly(libs.configlib.paper)
     compileOnly(libs.lombok)
+    compileOnly(libs.betterreload.api)
     annotationProcessor(libs.lombok)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ configlib = "4.5.0"
 shadow = "8.3.0"
 run-paper = "2.3.0"
 discord-webhooks = "0.8.0"
+betterreload = "v1.0.0"
 
 [libraries]
 paper-api = { module = "io.papermc.paper:paper-api", version.ref = "paper-api" }
@@ -14,6 +15,7 @@ packetevents-spigot = { group = "com.github.retrooper", name = "packetevents-spi
 configlib-yaml = { group = "de.exlll", name = "configlib-yaml", version.ref = "configlib" }
 configlib-paper = { group = "de.exlll", name = "configlib-paper", version.ref = "configlib" }
 discord-webhooks = { group = "club.minnced", name = "discord-webhooks", version.ref = "discord-webhooks" }
+betterreload-api = { group = "com.github.amnoah.betterreload", name = "api", version.ref = "betterreload" }
 
 [plugins]
 run-paper = { id = "xyz.jpenilla.run-paper", version.ref = "run-paper" }

--- a/src/main/java/com/deathmotion/totemguard/TotemGuard.java
+++ b/src/main/java/com/deathmotion/totemguard/TotemGuard.java
@@ -20,6 +20,7 @@ package com.deathmotion.totemguard;
 
 import com.deathmotion.totemguard.commands.TotemGuardCommand;
 import com.deathmotion.totemguard.config.ConfigManager;
+import com.deathmotion.totemguard.listeners.ReloadListener;
 import com.deathmotion.totemguard.listeners.UserTracker;
 import com.deathmotion.totemguard.manager.AlertManager;
 import com.deathmotion.totemguard.manager.CheckManager;
@@ -76,6 +77,8 @@ public final class TotemGuard extends JavaPlugin {
         punishmentManager = new PunishmentManager(this);
         checkManager = new CheckManager(this);
         PacketEvents.getAPI().getEventManager().registerListener(userTracker, PacketListenerPriority.LOW);
+        if (Bukkit.getPluginManager().getPlugin("BetterReload") != null)
+            Bukkit.getPluginManager().registerEvents(new ReloadListener(this), this);
 
         new TotemGuardCommand(this);
         new UpdateChecker(this);

--- a/src/main/java/com/deathmotion/totemguard/TotemGuard.java
+++ b/src/main/java/com/deathmotion/totemguard/TotemGuard.java
@@ -21,7 +21,6 @@ package com.deathmotion.totemguard;
 import com.deathmotion.totemguard.commands.TotemGuardCommand;
 import com.deathmotion.totemguard.config.ConfigManager;
 import com.deathmotion.totemguard.listeners.ReloadListener;
-import com.deathmotion.totemguard.listeners.UserTracker;
 import com.deathmotion.totemguard.manager.AlertManager;
 import com.deathmotion.totemguard.manager.CheckManager;
 import com.deathmotion.totemguard.manager.DiscordManager;

--- a/src/main/java/com/deathmotion/totemguard/listeners/ReloadListener.java
+++ b/src/main/java/com/deathmotion/totemguard/listeners/ReloadListener.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of TotemGuard - https://github.com/Bram1903/TotemGuard
+ * Copyright (C) 2024 Bram and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.deathmotion.totemguard.listeners;
+
+import better.reload.api.ReloadEvent;
+import com.deathmotion.totemguard.TotemGuard;
+import com.deathmotion.totemguard.config.ConfigManager;
+import com.deathmotion.totemguard.config.Settings;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class ReloadListener implements Listener {
+
+    private final ConfigManager configManager;
+
+    public ReloadListener(TotemGuard plugin) {
+        configManager = plugin.getConfigManager();
+    }
+
+    @EventHandler
+    public void onReloadEvent(ReloadEvent event) {
+        // Code directly copied from TotemGuardCommand#handleReloadCommand
+        configManager.reload();
+
+        final Settings settings = configManager.getSettings();
+
+        Component prefixMessage = Component.text()
+                .append(LegacyComponentSerializer.legacyAmpersand().deserialize(settings.getPrefix()))
+                .append(Component.text("The configuration has been reloaded!", NamedTextColor.GREEN))
+                .build();
+
+        event.getCommandSender().sendMessage(prefixMessage);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -12,6 +12,8 @@ libraries:
   - club.minnced:discord-webhooks:${discordWebhooksVersion}
 depend:
   - packetevents
+softdepend:
+  - BetterReload
 permissions:
   TotemGuard.*:
     description: Gives access to all TotemGuard permissions.


### PR DESCRIPTION
I'm not sure of how open you would be to this feature, but I added this feature for my own server so I figured I'd offer the contribution.

This PR adds support for [BetterReload](https://github.com/amnoah/BetterReload) - a plugin that overrides the /reload command and sends out an event in its place to plugins that can either be handled or ignored. This leaves the reloading process up to plugins and leaves no sketchy behavior in the process.

This is a completely optional dependency, only having any function when the BetterReload plugin is installed alongside TotemGuard.

For more information about BetterReload here are some links:
[Source Code](https://github.com/amnoah/BetterReload)
[Documentation](https://github.com/amnoah/BetterReload/wiki)
[Modrinth](https://modrinth.com/plugin/betterreload)

Thank you so much for your time, and have a great day!