### PR TITLE
[Feat] BadPacketC: Impossible slot change packet check

### DIFF
--- a/src/main/java/com/deathmotion/totemguard/checks/impl/badpackets/BadPacketsC.java
+++ b/src/main/java/com/deathmotion/totemguard/checks/impl/badpackets/BadPacketsC.java
@@ -54,10 +54,12 @@ public final class BadPacketsC extends Check implements PacketListener {
 
         WrapperPlayClientSlotStateChange packet = new WrapperPlayClientSlotStateChange(event);
         int slot = packet.getSlot();
+        plugin.debug("Slot: " + slot);
         UUID playerUUID = event.getUser().getUUID();
 
         Integer lastSlot = playerLastSlotMap.get(playerUUID);
         if (lastSlot != null && lastSlot == slot) {
+            plugin.debug("Same slot packet " + slot);
             final Settings.Checks.BadPacketsC settings = plugin.getConfigManager().getSettings().getChecks().getBadPacketsC();
             flag(event.getPlayer(), getCheckDetails(slot, lastSlot), settings);
         }
@@ -81,10 +83,10 @@ public final class BadPacketsC extends Check implements PacketListener {
         Pair<TextColor, TextColor> colorScheme = messageService.getColorScheme();
 
         return Component.text()
-                .append(Component.text("slot: ", colorScheme.getY()))
+                .append(Component.text("New Slot Change: ", colorScheme.getY()))
                 .append(Component.text(slot, colorScheme.getX()))
                 .append(Component.newline())
-                .append(Component.text("lastSlot: ", colorScheme.getY()))
+                .append(Component.text("Last Slot Change: ", colorScheme.getY()))
                 .append(Component.text(lastSlot, colorScheme.getX()))
                 .build();
     }

--- a/src/main/java/com/deathmotion/totemguard/checks/impl/badpackets/BadPacketsC.java
+++ b/src/main/java/com/deathmotion/totemguard/checks/impl/badpackets/BadPacketsC.java
@@ -54,12 +54,10 @@ public final class BadPacketsC extends Check implements PacketListener {
 
         WrapperPlayClientHeldItemChange packet = new WrapperPlayClientHeldItemChange(event);
         int slot = packet.getSlot();
-        plugin.debug("Slot: " + slot);
         UUID playerUUID = event.getUser().getUUID();
 
         Integer lastSlot = playerLastSlotMap.get(playerUUID);
         if (lastSlot != null && lastSlot == slot) {
-            plugin.debug("Same slot packet " + slot);
             final Settings.Checks.BadPacketsC settings = plugin.getConfigManager().getSettings().getChecks().getBadPacketsC();
             flag(event.getPlayer(), getCheckDetails(slot, lastSlot), settings);
         }

--- a/src/main/java/com/deathmotion/totemguard/checks/impl/badpackets/BadPacketsC.java
+++ b/src/main/java/com/deathmotion/totemguard/checks/impl/badpackets/BadPacketsC.java
@@ -26,7 +26,7 @@ import com.deathmotion.totemguard.util.datastructure.Pair;
 import com.github.retrooper.packetevents.event.PacketListener;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientSlotStateChange;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientHeldItemChange;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextColor;
 
@@ -48,11 +48,11 @@ public final class BadPacketsC extends Check implements PacketListener {
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() != PacketType.Play.Client.SLOT_STATE_CHANGE) {
+        if (event.getPacketType() != PacketType.Play.Client.HELD_ITEM_CHANGE) {
             return;
         }
 
-        WrapperPlayClientSlotStateChange packet = new WrapperPlayClientSlotStateChange(event);
+        WrapperPlayClientHeldItemChange packet = new WrapperPlayClientHeldItemChange(event);
         int slot = packet.getSlot();
         plugin.debug("Slot: " + slot);
         UUID playerUUID = event.getUser().getUUID();

--- a/src/main/java/com/deathmotion/totemguard/checks/impl/badpackets/BadPacketsC.java
+++ b/src/main/java/com/deathmotion/totemguard/checks/impl/badpackets/BadPacketsC.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of TotemGuard - https://github.com/Bram1903/TotemGuard
+ * Copyright (C) 2024 Bram and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.deathmotion.totemguard.checks.impl.badpackets;
+
+import com.deathmotion.totemguard.TotemGuard;
+import com.deathmotion.totemguard.checks.Check;
+import com.deathmotion.totemguard.config.Settings;
+import com.deathmotion.totemguard.util.MessageService;
+import com.deathmotion.totemguard.util.datastructure.Pair;
+import com.github.retrooper.packetevents.event.PacketListener;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPluginMessage;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientSlotStateChange;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextColor;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+public final class BadPacketsC extends Check implements PacketListener {
+
+    private final TotemGuard plugin;
+    private final MessageService messageService;
+    private final HashMap<UUID, Integer> playerlastSlotmap;
+
+    public BadPacketsC(TotemGuard plugin) {
+        super(plugin, "BadPacketsC", "Impossible same slot packet");
+        this.plugin = plugin;
+        this.messageService = plugin.getMessageService();
+        this.playerlastSlotmap = new HashMap<>();
+    }
+
+    @Override
+    public void onPacketReceive(PacketReceiveEvent event) {
+        if (event.getPacketType() != PacketType.Play.Client.SLOT_STATE_CHANGE) {
+            return;
+        }
+
+        WrapperPlayClientSlotStateChange packet = new WrapperPlayClientSlotStateChange(event);
+        int slot = packet.getSlot();
+        UUID playerUUID = event.getUser().getUUID();
+
+        Integer lastSlot = playerlastSlotmap.get(playerUUID);
+        if (lastSlot != null && lastSlot == slot) {
+            final Settings.Checks.BadPacketsC settings = plugin.getConfigManager().getSettings().getChecks().getBadPacketsC();
+            flag(event.getPlayer(), getCheckDetails(slot, lastSlot), settings);
+        }
+
+        playerlastSlotmap.put(playerUUID, slot);
+    }
+
+    @Override
+    public void resetData() {
+        super.resetData();
+    }
+
+    @Override
+    public void resetData(UUID uuid) {
+        super.resetData(uuid);
+    }
+
+    private Component getCheckDetails(int slot, int lastSlot) {
+        Pair<TextColor, TextColor> colorScheme = messageService.getColorScheme();
+
+        return Component.text()
+                .append(Component.text("slot: ", colorScheme.getY()))
+                .append(Component.text(slot, colorScheme.getX()))
+                .append(Component.newline())
+                .append(Component.text("lastSlot: ", colorScheme.getY()))
+                .append(Component.text(lastSlot, colorScheme.getX()))
+                .build();
+    }
+}

--- a/src/main/java/com/deathmotion/totemguard/config/Settings.java
+++ b/src/main/java/com/deathmotion/totemguard/config/Settings.java
@@ -260,6 +260,9 @@ public final class Settings {
         @Comment("\nBadPacketB Settings")
         private BadPacketsB badPacketsB = new BadPacketsB();
 
+        @Comment("\nBadPacketC Settings")
+        private BadPacketsC badPacketsC = new BadPacketsC();
+
         @Comment("\nManualTotemA Settings")
         private ManualTotemA manualTotemA = new ManualTotemA();
 
@@ -381,6 +384,7 @@ public final class Settings {
             }
         }
 
+
         @Configuration
         @Getter
         public static class BadPacketsB extends CheckSettings {
@@ -391,6 +395,13 @@ public final class Settings {
 
             public BadPacketsB() {
                 super(true, 30, 1);
+            }
+        }
+
+        @Configuration
+        @Getter
+        public static class BadPacketsC extends CheckSettings {
+            public BadPacketsC() {super(true, 30, 1);
             }
         }
 

--- a/src/main/java/com/deathmotion/totemguard/config/Settings.java
+++ b/src/main/java/com/deathmotion/totemguard/config/Settings.java
@@ -89,11 +89,11 @@ public final class Settings {
     @Getter
     public static class ProxyAlerts {
         @Comment({
-            "Proxy messaging method",
-            "How should be send and receive messages from sibling servers?",
-            "Options:",
-            " - plugin-messaging (Will use plugin messaging through player connections.)",
-            " - redis (Requires further configuration in the 'redis' section below.)"
+                "Proxy messaging method",
+                "How should be send and receive messages from sibling servers?",
+                "Options:",
+                " - plugin-messaging (Will use plugin messaging through player connections.)",
+                " - redis (Requires further configuration in the 'redis' section below.)"
         })
         private String method = "plugin-messaging";
 
@@ -401,7 +401,8 @@ public final class Settings {
         @Configuration
         @Getter
         public static class BadPacketsC extends CheckSettings {
-            public BadPacketsC() {super(true, 30, 1);
+            public BadPacketsC() {
+                super(true, 30, 1);
             }
         }
 

--- a/src/main/java/com/deathmotion/totemguard/manager/CheckManager.java
+++ b/src/main/java/com/deathmotion/totemguard/manager/CheckManager.java
@@ -22,6 +22,7 @@ import com.deathmotion.totemguard.TotemGuard;
 import com.deathmotion.totemguard.checks.ICheck;
 import com.deathmotion.totemguard.checks.impl.badpackets.BadPacketsA;
 import com.deathmotion.totemguard.checks.impl.badpackets.BadPacketsB;
+import com.deathmotion.totemguard.checks.impl.badpackets.BadPacketsC;
 import com.deathmotion.totemguard.checks.impl.totem.*;
 import com.deathmotion.totemguard.checks.impl.totem.processor.TotemProcessor;
 import com.deathmotion.totemguard.commands.totemguard.CheckCommand;
@@ -68,6 +69,7 @@ public class CheckManager {
                 new AutoTotemE(plugin),
                 new AutoTotemF(plugin),
                 new BadPacketsA(plugin),
+                new BadPacketsC(plugin),
                 BadPacketsB.getInstance(plugin),
                 CheckCommand.getInstance(plugin)
         );


### PR DESCRIPTION
In minecraft its impossible to send the same slot packet.

I've had this check in my anticheat as a general badpackets check for a while, I've noticed it flags many poorly built modules like Autototem, CrystalAura, AnchorAura, CartAura (in a private client).

Even though this is a very basic check, alot of clients somehow mess this up. Pretty Sure meteor or some other popular client flags this lol.

ps; not sure if I implemented it correctly, im not familiar with this base so do make sure it works.
