### PR TITLE
Added: AutoTotemG (Swap Hand Check)

### DIFF
--- a/src/main/java/com/deathmotion/totemguard/checks/impl/autototem/AutoTotemF.java
+++ b/src/main/java/com/deathmotion/totemguard/checks/impl/autototem/AutoTotemF.java
@@ -35,6 +35,7 @@ import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 
 @CheckData(name = "AutoTotemF", description = "Invalid interaction", experimental = true)
@@ -64,7 +65,13 @@ public class AutoTotemF extends Check implements BukkitEventCheck {
         if (inventory == null || inventory.getType() != InventoryType.PLAYER) return;
         if (!ValidClickTypes.isClickTypeValid((event.getClick()))) return;
 
-        if (event.getCurrentItem() != null && event.getCurrentItem().getType() == Material.TOTEM_OF_UNDYING) {
+        ItemStack item = event.getCurrentItem();
+        int hotbar = event.getHotbarButton();
+        ItemStack hotbarItem = null;
+        if (hotbar >= 0) {
+            hotbarItem = player.bukkitPlayer.getInventory().getItem(hotbar);
+        }
+        if ((item != null && item.getType() == Material.TOTEM_OF_UNDYING) || (hotbarItem != null && hotbarItem.getType() == Material.TOTEM_OF_UNDYING)) {
             inventoryClickTime = System.currentTimeMillis();
         }
     }

--- a/src/main/java/com/deathmotion/totemguard/checks/impl/autototem/AutoTotemG.java
+++ b/src/main/java/com/deathmotion/totemguard/checks/impl/autototem/AutoTotemG.java
@@ -1,0 +1,167 @@
+/*
+ * This file is part of TotemGuard - https://github.com/Bram1903/TotemGuard
+ * Copyright (C) 2025 Bram and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.deathmotion.totemguard.checks.impl.autototem;
+
+import com.deathmotion.totemguard.TotemGuard;
+import com.deathmotion.totemguard.checks.Check;
+import com.deathmotion.totemguard.checks.CheckData;
+import com.deathmotion.totemguard.checks.type.BukkitEventCheck;
+import com.deathmotion.totemguard.models.TotemPlayer;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Material;
+import org.bukkit.event.Event;
+import org.bukkit.event.entity.EntityResurrectEvent;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+
+@CheckData(name = "AutoTotemG", description = "Monitors swap-hand timings")
+public class AutoTotemG extends Check implements BukkitEventCheck {
+
+    private Long lastTotemUse;
+    private Long lastClickTime;
+
+    public AutoTotemG(TotemPlayer playerData) {
+        super(playerData);
+    }
+
+    @Override
+    public void onBukkitEvent(Event event) {
+        if (event instanceof EntityResurrectEvent) {
+            handleEntityResurrection();
+        }
+        if (event instanceof InventoryClickEvent invClickEvent) {
+            handleInventoryClick(invClickEvent);
+        }
+        if (event instanceof PlayerSwapHandItemsEvent swapHandItemsEvent) {
+            handleSwapHandItems(swapHandItemsEvent);
+        }
+    }
+
+    /**
+     * Records the moment a totem is used (if conditions are met).
+     */
+    private void handleEntityResurrection() {
+        PlayerInventory playerInventory = player.bukkitPlayer.getInventory();
+
+        // Ensure the main hand doesn't already have a Totem, and at least 2 Totems exist in the inventory
+        if (playerInventory.getItemInMainHand().getType() == Material.TOTEM_OF_UNDYING) return;
+        if (!playerInventory.containsAtLeast(new ItemStack(Material.TOTEM_OF_UNDYING), 2)) return;
+
+        lastTotemUse = System.currentTimeMillis();
+    }
+
+    /**
+     * Tracks inventory clicks to capture the time of a Totem click.
+     */
+    private void handleInventoryClick(InventoryClickEvent event) {
+        // Moving Totem to hotbar
+        ClickType click = event.getClick();
+        if (click == ClickType.NUMBER_KEY || click == ClickType.SHIFT_LEFT || click == ClickType.SHIFT_RIGHT) {
+            ItemStack item = event.getCurrentItem();
+            int hotbar = event.getHotbarButton();
+            ItemStack hotbarItem = null;
+            if (hotbar >= 0) {
+                hotbarItem = player.bukkitPlayer.getInventory().getItem(hotbar);
+            }
+            if ((item != null && item.getType() == Material.TOTEM_OF_UNDYING) || (hotbarItem != null && hotbarItem.getType() == Material.TOTEM_OF_UNDYING)) {
+                lastClickTime = System.currentTimeMillis();
+            }
+        }
+    }
+
+    /**
+     * Tracks swap-hand actions to capture the time of a Totem swap.
+     */
+    private void handleSwapHandItems(PlayerSwapHandItemsEvent event) {
+        // Moving Totem to off-hand
+        if (event.getOffHandItem().getType() == Material.TOTEM_OF_UNDYING) {
+            if (lastClickTime != null && lastTotemUse != null) {
+                evaluateSuspicion();
+            }
+        }
+    }
+
+    /**
+     * Validates whether the behavior is suspicious by comparing relevant time intervals.
+     */
+    private void evaluateSuspicion() {
+        long now = System.currentTimeMillis();
+        long timeSinceTotemUse = Math.abs(now - lastTotemUse);
+        long timeSinceClick = Math.abs(now - lastClickTime);
+        long adjustedTotemTime = Math.abs(timeSinceTotemUse - player.getKeepAlivePing());
+
+        var config = TotemGuard.getInstance().getConfigManager().getChecks().getAutoTotemG();
+
+        // If both the time after click and time since totem usage are under the configured thresholds, flag.
+        if (timeSinceClick <= config.getClickToSwapTimeDifference() && timeSinceTotemUse <= config.getNormalCheckTimeMs()) {
+            fail(createDetails(timeSinceTotemUse, adjustedTotemTime, timeSinceClick));
+        }
+
+        lastTotemUse = null;
+    }
+
+    private Component createDetails(long timeDifference, long realTotemTime, long clickTimeDifference) {
+        Component component = Component.text()
+                .append(Component.text("Totem Time: ", color.getX()))
+                .append(Component.text(timeDifference + "ms", color.getY()))
+                .append(Component.newline())
+                .append(Component.text("Real Totem Time: ", color.getX()))
+                .append(Component.text(realTotemTime + "ms", color.getY()))
+                .append(Component.newline())
+                .append(Component.text("Click Difference: ", color.getX()))
+                .append(Component.text(clickTimeDifference + "ms", color.getY()))
+                .append(Component.newline())
+                .append(Component.text("Main Hand: ", color.getX()))
+                .append(Component.text(getMainHandItemString(), color.getY()))
+                .build();
+
+        StringBuilder states = new StringBuilder();
+        if (player.bukkitPlayer.isSprinting()) {
+            states.append("Sprinting, ");
+        }
+        if (player.bukkitPlayer.isSneaking()) {
+            states.append("Sneaking, ");
+        }
+        if (player.bukkitPlayer.isBlocking()) {
+            states.append("Blocking, ");
+        }
+
+        // If any states are active, add them to the component
+        if (!states.isEmpty()) {
+            states.setLength(states.length() - 2); // Remove trailing comma and space
+            component = component
+                    .append(Component.newline())
+                    .append(Component.text("States: ", color.getX()))
+                    .append(Component.text(states.toString(), color.getY()));
+        }
+
+        return component;
+    }
+
+    private String getMainHandItemString() {
+        PlayerInventory inventory = player.bukkitPlayer.getInventory();
+
+        return inventory.getItemInMainHand().getType() == Material.AIR
+                ? "Empty Hand"
+                : inventory.getItemInMainHand().getType().toString();
+    }
+}

--- a/src/main/java/com/deathmotion/totemguard/config/Checks.java
+++ b/src/main/java/com/deathmotion/totemguard/config/Checks.java
@@ -51,6 +51,9 @@ public class Checks {
     @Comment("\nAutoTotemF")
     private AutoTotemF autoTotemF = new AutoTotemF();
 
+    @Comment("\nAutoTotemG")
+    private AutoTotemG autoTotemG = new AutoTotemG();
+
     @Comment("\nBadPacketsA")
     private BadPacketsA badPacketsA = new BadPacketsA();
 
@@ -74,6 +77,7 @@ public class Checks {
             case "AutoTotemD" -> autoTotemD;
             case "AutoTotemE" -> autoTotemE;
             case "AutoTotemF" -> autoTotemF;
+            case "AutoTotemG" -> autoTotemG;
             case "BadPacketsA" -> badPacketsA;
             case "BadPacketsB" -> badPacketsB;
             case "BadPacketsC" -> badPacketsC;
@@ -191,6 +195,20 @@ public class Checks {
 
         public AutoTotemF() {
             super(false, 20);
+        }
+    }
+
+    @Configuration
+    @Getter
+    public static class AutoTotemG extends CheckSettings {
+        @Comment("\nNormal Check Time: Sets the interval (in ms) for normal checks.")
+        private int normalCheckTimeMs = 1500;
+
+        @Comment("\nClick to Swap Time Difference: The value (in ms) which anything below will trigger the flag.")
+        private int clickToSwapTimeDifference = 75;
+
+        public AutoTotemG() {
+            super(false, 4);
         }
     }
 

--- a/src/main/java/com/deathmotion/totemguard/events/bukkit/CheckManagerBukkitListener.java
+++ b/src/main/java/com/deathmotion/totemguard/events/bukkit/CheckManagerBukkitListener.java
@@ -63,7 +63,12 @@ public class CheckManagerBukkitListener implements Listener {
 
         if (totemPlayer.totemData.isExpectingTotemSwap()) {
             ItemStack item = event.getCurrentItem();
-            if (item != null && item.getType() == Material.TOTEM_OF_UNDYING) {
+            int hotbar = event.getHotbarButton();
+            ItemStack hotbarItem = null;
+            if (hotbar >= 0) {
+                hotbarItem = player.getInventory().getItem(hotbar);
+            }
+            if ((item != null && item.getType() == Material.TOTEM_OF_UNDYING) || (hotbarItem != null && hotbarItem.getType() == Material.TOTEM_OF_UNDYING)) {
                 callTotemCycleHandlers(totemPlayer);
             }
         }
@@ -86,10 +91,13 @@ public class CheckManagerBukkitListener implements Listener {
         TotemPlayer totemPlayer = TotemGuard.getInstance().getPlayerDataManager().getPlayer(event.getPlayer());
         if (totemPlayer == null) return;
 
-        if (!totemPlayer.totemData.isExpectingTotemSwap()) return;
-        if (event.getOffHandItem().getType() != Material.TOTEM_OF_UNDYING) return;
+        if (totemPlayer.totemData.isExpectingTotemSwap()) {
+            if (event.getOffHandItem().getType() == Material.TOTEM_OF_UNDYING) {
+                callTotemCycleHandlers(totemPlayer);
+            }
+        }
 
-        callTotemCycleHandlers(totemPlayer);
+        totemPlayer.checkManager.onBukkitEvent(event);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/src/main/java/com/deathmotion/totemguard/manager/CheckManager.java
+++ b/src/main/java/com/deathmotion/totemguard/manager/CheckManager.java
@@ -57,6 +57,7 @@ public class CheckManager {
                 .put(AutoTotemC.class, new AutoTotemC(player))
                 .put(AutoTotemE.class, new AutoTotemE(player))
                 .put(AutoTotemF.class, new AutoTotemF(player))
+                .put(AutoTotemG.class, new AutoTotemG(player))
                 .build();
 
         genericChecks = new ImmutableClassToInstanceMap.Builder<GenericCheck>()


### PR DESCRIPTION
1. Add a new check for the time difference between inventory clicks and swaps.
2. Fix an issue in InventoryClickEvent where equipping a totem using the number key is ignored.

The new check was tested using the Autototem 1.0.6 mod (without the mod configuration channel):
https://modrinth.com/mod/autototem