### PR TITLE
fix: run /tg check target logic on the target's region thread (Folia/Canvas) 

### DIFF
--- a/src/main/java/com/deathmotion/totemguard/commands/impl/CheckCommand.java
+++ b/src/main/java/com/deathmotion/totemguard/commands/impl/CheckCommand.java
@@ -114,6 +114,10 @@ public final class CheckCommand extends AbstractCommand {
             return;
         }
 
+        FoliaScheduler.getEntityScheduler().run(target, plugin, (o) -> performCheck(sender, target, totemPlayer, checkDuration), null);
+    }
+
+    private void performCheck(CommandSender sender, Player target, TotemPlayer totemPlayer, int checkDuration) {
         // Ensure the target is in a valid state (survival/adventure, not invulnerable, has totem).
         if (!isTargetInValidGameState(sender, target)) {
             return;


### PR DESCRIPTION
I had a problem where the `tg check` command wasn't working properly on Folia or Canvas, so I just thought I'll PR this quickly : ) 

The problem was simply that it wasn't running on the correct thread; it should now run on the entity region thread.

For in case you'd like to see the entire error; https://pastebin.com/hfTsemq4